### PR TITLE
Use develop-3.2 branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,3 @@
 %%-*- mode: erlang -*-
 {cover_enabled, true}.
-{deps, [{riakc, ".", {git, "https://github.com/basho/riak-erlang-client.git", "HEAD"}}]}.
+{deps, [{riakc, ".", {git, "https://github.com/basho/riak-erlang-client.git", {branch, "develop-3.2"}}}]}.


### PR DESCRIPTION
Use the `develop-3.2` branch of the `riak-erlang-client` instead of `main`/`HEAD` which is always changing.